### PR TITLE
feat: add support for multiple new file types

### DIFF
--- a/Unsiloed/routes/chunking_routes.py
+++ b/Unsiloed/routes/chunking_routes.py
@@ -44,10 +44,37 @@ async def chunk_document(
     elif file_name.endswith(".pptx"):
         file_type = "pptx"
         file_suffix = ".pptx"
+    elif file_name.endswith(".doc"):
+        file_type = "doc"
+        file_suffix = ".doc"
+    elif file_name.endswith(".xlsx"):
+        file_type = "xlsx"
+        file_suffix = ".xlsx"
+    elif file_name.endswith(".xls"):
+        file_type = "xls"
+        file_suffix = ".xls"
+    elif file_name.endswith(".odt"):
+        file_type = "odt"
+        file_suffix = ".odt"
+    elif file_name.endswith(".ods"):
+        file_type = "ods"
+        file_suffix = ".ods"
+    elif file_name.endswith(".odp"):
+        file_type = "odp"
+        file_suffix = ".odp"
+    elif file_name.endswith(".txt"):
+        file_type = "txt"
+        file_suffix = ".txt"
+    elif file_name.endswith(".rtf"):
+        file_type = "rtf"
+        file_suffix = ".rtf"
+    elif file_name.endswith(".epub"):
+        file_type = "epub"
+        file_suffix = ".epub"
     else:
         raise HTTPException(
             status_code=400,
-            detail="Unsupported file type. Only PDF, DOCX, and PPTX are supported.",
+            detail="Unsupported file type. Supported formats: PDF, DOCX, PPTX, DOC, XLSX, XLS, ODT, ODS, ODP, TXT, RTF, EPUB",
         )
 
     file_path = None  # Initialize file_path

--- a/Unsiloed/services/chunking.py
+++ b/Unsiloed/services/chunking.py
@@ -9,6 +9,15 @@ from Unsiloed.utils.openai import (
     extract_text_from_pdf,
     extract_text_from_docx,
     extract_text_from_pptx,
+    extract_text_from_doc,
+    extract_text_from_xlsx,
+    extract_text_from_xls,
+    extract_text_from_odt,
+    extract_text_from_ods,
+    extract_text_from_odp,
+    extract_text_from_txt,
+    extract_text_from_rtf,
+    extract_text_from_epub,
 )
 
 import logging
@@ -24,11 +33,11 @@ def process_document_chunking(
     overlap=100,
 ):
     """
-    Process a document file (PDF, DOCX, PPTX) with the specified chunking strategy.
+    Process a document file with the specified chunking strategy.
 
     Args:
         file_path: Path to the document file
-        file_type: Type of document (pdf, docx, pptx)
+        file_type: Type of document (pdf, docx, pptx, doc, xlsx, xls, odt, ods, odp, txt, rtf, epub)
         strategy: Chunking strategy to use
         chunk_size: Size of chunks for fixed strategy
         overlap: Overlap size for fixed strategy
@@ -51,6 +60,24 @@ def process_document_chunking(
             text = extract_text_from_docx(file_path)
         elif file_type == "pptx":
             text = extract_text_from_pptx(file_path)
+        elif file_type == "doc":
+            text = extract_text_from_doc(file_path)
+        elif file_type == "xlsx":
+            text = extract_text_from_xlsx(file_path)
+        elif file_type == "xls":
+            text = extract_text_from_xls(file_path)
+        elif file_type == "odt":
+            text = extract_text_from_odt(file_path)
+        elif file_type == "ods":
+            text = extract_text_from_ods(file_path)
+        elif file_type == "odp":
+            text = extract_text_from_odp(file_path)
+        elif file_type == "txt":
+            text = extract_text_from_txt(file_path)
+        elif file_type == "rtf":
+            text = extract_text_from_rtf(file_path)
+        elif file_type == "epub":
+            text = extract_text_from_epub(file_path)
         else:
             raise ValueError(f"Unsupported file type: {file_type}")
 

--- a/Unsiloed/utils/openai.py
+++ b/Unsiloed/utils/openai.py
@@ -485,3 +485,204 @@ def extract_text_from_pptx(pptx_path: str) -> str:
     except Exception as e:
         logger.error(f"Error extracting text from PPTX: {str(e)}")
         raise
+
+
+def extract_text_from_doc(doc_path: str) -> str:
+    """
+    Extract text from a legacy DOC file.
+
+    Args:
+        doc_path: Path to the DOC file
+
+    Returns:
+        Extracted text from the DOC file
+    """
+    try:
+        import textract
+
+        return textract.process(doc_path).decode("utf-8")
+    except Exception as e:
+        logger.error(f"Error extracting text from DOC: {str(e)}")
+        raise
+
+
+def extract_text_from_xlsx(xlsx_path: str) -> str:
+    """
+    Extract text from an XLSX file.
+
+    Args:
+        xlsx_path: Path to the XLSX file
+
+    Returns:
+        Extracted text from the XLSX file
+    """
+    try:
+        import pandas as pd
+
+        text = []
+        xls = pd.ExcelFile(xlsx_path)
+        for sheet_name in xls.sheet_names:
+            df = pd.read_excel(xlsx_path, sheet_name=sheet_name)
+            text.append(f"Sheet: {sheet_name}\n")
+            text.append(df.to_string())
+            text.append("\n\n")
+        return "\n".join(text)
+    except Exception as e:
+        logger.error(f"Error extracting text from XLSX: {str(e)}")
+        raise
+
+
+def extract_text_from_xls(xls_path: str) -> str:
+    """
+    Extract text from a legacy XLS file.
+
+    Args:
+        xls_path: Path to the XLS file
+
+    Returns:
+        Extracted text from the XLS file
+    """
+    try:
+        import pandas as pd
+
+        text = []
+        xls = pd.ExcelFile(xls_path)
+        for sheet_name in xls.sheet_names:
+            df = pd.read_excel(xls_path, sheet_name=sheet_name)
+            text.append(f"Sheet: {sheet_name}\n")
+            text.append(df.to_string())
+            text.append("\n\n")
+        return "\n".join(text)
+    except Exception as e:
+        logger.error(f"Error extracting text from XLS: {str(e)}")
+        raise
+
+
+def extract_text_from_odt(odt_path: str) -> str:
+    """
+    Extract text from an ODT file.
+
+    Args:
+        odt_path: Path to the ODT file
+
+    Returns:
+        Extracted text from the ODT file
+    """
+    try:
+        import textract
+
+        return textract.process(odt_path).decode("utf-8")
+    except Exception as e:
+        logger.error(f"Error extracting text from ODT: {str(e)}")
+        raise
+
+
+def extract_text_from_ods(ods_path: str) -> str:
+    """
+    Extract text from an ODS file.
+
+    Args:
+        ods_path: Path to the ODS file
+
+    Returns:
+        Extracted text from the ODS file
+    """
+    try:
+        import pandas as pd
+
+        text = []
+        df = pd.read_excel(ods_path, engine="odf")
+        text.append(df.to_string())
+        return "\n".join(text)
+    except Exception as e:
+        logger.error(f"Error extracting text from ODS: {str(e)}")
+        raise
+
+
+def extract_text_from_odp(odp_path: str) -> str:
+    """
+    Extract text from an ODP file.
+
+    Args:
+        odp_path: Path to the ODP file
+
+    Returns:
+        Extracted text from the ODP file
+    """
+    try:
+        import textract
+
+        return textract.process(odp_path).decode("utf-8")
+    except Exception as e:
+        logger.error(f"Error extracting text from ODP: {str(e)}")
+        raise
+
+
+def extract_text_from_txt(txt_path: str) -> str:
+    """
+    Extract text from a TXT file.
+
+    Args:
+        txt_path: Path to the TXT file
+
+    Returns:
+        Extracted text from the TXT file
+    """
+    try:
+        with open(txt_path, "r", encoding="utf-8") as file:
+            return file.read()
+    except UnicodeDecodeError:
+        # Try with a different encoding if UTF-8 fails
+        with open(txt_path, "r", encoding="latin-1") as file:
+            return file.read()
+    except Exception as e:
+        logger.error(f"Error extracting text from TXT: {str(e)}")
+        raise
+
+
+def extract_text_from_rtf(rtf_path: str) -> str:
+    """
+    Extract text from an RTF file.
+
+    Args:
+        rtf_path: Path to the RTF file
+
+    Returns:
+        Extracted text from the RTF file
+    """
+    try:
+        import textract
+
+        return textract.process(rtf_path).decode("utf-8")
+    except Exception as e:
+        logger.error(f"Error extracting text from RTF: {str(e)}")
+        raise
+
+
+def extract_text_from_epub(epub_path: str) -> str:
+    """
+    Extract text from an EPUB file.
+
+    Args:
+        epub_path: Path to the EPUB file
+
+    Returns:
+        Extracted text from the EPUB file
+    """
+    try:
+        import ebooklib
+        from ebooklib import epub
+        from bs4 import BeautifulSoup
+
+        book = epub.read_epub(epub_path)
+        text = []
+
+        for item in book.get_items():
+            if item.get_type() == ebooklib.ITEM_DOCUMENT:
+                soup = BeautifulSoup(item.get_content(), "html.parser")
+                text.append(soup.get_text())
+
+        return "\n\n".join(text)
+    except Exception as e:
+        logger.error(f"Error extracting text from EPUB: {str(e)}")
+        raise


### PR DESCRIPTION
### 📌 Summary

This PR extends the OCR/Extraction service to support multiple additional file types beyond the currently supported formats (PDF, DOCX, PPTX).

---

### ✅ Added File Type Support

- `.DOC` (Microsoft Word 97–2003)
- `.XLS`, `.XLSX` (Microsoft Excel formats)
- `.ODT`, `.ODS`, `.ODP` (OpenDocument formats)
- `.TXT` (Plain text)
- `.RTF` (Rich Text Format)
- `.EPUB` (eBook format)

Fixes #3
/claim #3