### PR TITLE
Add Support for Multiple OCR/LLM Models Beyond OpenAI (Anthropic, Hugging Face, Local LLMs)

### DIFF
--- a/Unsiloed/config.py
+++ b/Unsiloed/config.py
@@ -1,0 +1,165 @@
+"""
+Configuration module for Unsiloed.
+"""
+
+import os
+import logging
+from typing import Dict, Any, Optional
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+class Config:
+    """
+    Configuration class for Unsiloed.
+    """
+
+    # Default configuration
+    DEFAULT_CONFIG = {
+        "model_provider": "openai",
+        "openai": {
+            "api_key": None,
+            "model": "gpt-4o",
+            "timeout": 60.0,
+            "max_retries": 3,
+        },
+        "anthropic": {
+            "api_key": None,
+            "model": "claude-3-opus-20240229",
+            "timeout": 60.0,
+            "max_retries": 3,
+        },
+        "huggingface": {
+            "api_key": None,
+            "model": "mistralai/Mistral-7B-Instruct-v0.2",
+            "api_url": None,
+            "timeout": 60.0,
+        },
+        "local": {
+            "model_path": None,
+            "n_ctx": 2048,
+            "n_gpu_layers": -1,
+            "verbose": False,
+        },
+    }
+
+    def __init__(self):
+        """
+        Initialize the configuration.
+        """
+        self.config = self.DEFAULT_CONFIG.copy()
+        self._load_from_env()
+
+    def _load_from_env(self):
+        """
+        Load configuration from environment variables.
+        """
+        # Model provider
+        self.config["model_provider"] = os.environ.get(
+            "UNSILOED_MODEL_PROVIDER", self.config["model_provider"]
+        )
+
+        # OpenAI configuration
+        self.config["openai"]["api_key"] = os.environ.get(
+            "OPENAI_API_KEY", self.config["openai"]["api_key"]
+        )
+        self.config["openai"]["model"] = os.environ.get(
+            "OPENAI_MODEL", self.config["openai"]["model"]
+        )
+        self.config["openai"]["timeout"] = float(
+            os.environ.get("OPENAI_TIMEOUT", self.config["openai"]["timeout"])
+        )
+        self.config["openai"]["max_retries"] = int(
+            os.environ.get("OPENAI_MAX_RETRIES", self.config["openai"]["max_retries"])
+        )
+
+        # Anthropic configuration
+        self.config["anthropic"]["api_key"] = os.environ.get(
+            "ANTHROPIC_API_KEY", self.config["anthropic"]["api_key"]
+        )
+        self.config["anthropic"]["model"] = os.environ.get(
+            "ANTHROPIC_MODEL", self.config["anthropic"]["model"]
+        )
+        self.config["anthropic"]["timeout"] = float(
+            os.environ.get("ANTHROPIC_TIMEOUT", self.config["anthropic"]["timeout"])
+        )
+        self.config["anthropic"]["max_retries"] = int(
+            os.environ.get(
+                "ANTHROPIC_MAX_RETRIES", self.config["anthropic"]["max_retries"]
+            )
+        )
+
+        # Hugging Face configuration
+        self.config["huggingface"]["api_key"] = os.environ.get(
+            "HUGGINGFACE_API_KEY", self.config["huggingface"]["api_key"]
+        )
+        self.config["huggingface"]["model"] = os.environ.get(
+            "HUGGINGFACE_MODEL", self.config["huggingface"]["model"]
+        )
+        self.config["huggingface"]["api_url"] = os.environ.get(
+            "HUGGINGFACE_API_URL", self.config["huggingface"]["api_url"]
+        )
+        self.config["huggingface"]["timeout"] = float(
+            os.environ.get("HUGGINGFACE_TIMEOUT", self.config["huggingface"]["timeout"])
+        )
+
+        # Local LLM configuration
+        self.config["local"]["model_path"] = os.environ.get(
+            "LOCAL_MODEL_PATH", self.config["local"]["model_path"]
+        )
+        self.config["local"]["n_ctx"] = int(
+            os.environ.get("LOCAL_N_CTX", self.config["local"]["n_ctx"])
+        )
+        self.config["local"]["n_gpu_layers"] = int(
+            os.environ.get("LOCAL_N_GPU_LAYERS", self.config["local"]["n_gpu_layers"])
+        )
+        self.config["local"]["verbose"] = (
+            os.environ.get("LOCAL_VERBOSE", "").lower() == "true"
+        )
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """
+        Get a configuration value.
+
+        Args:
+            key: Configuration key
+            default: Default value if key is not found
+
+        Returns:
+            Configuration value
+        """
+        keys = key.split(".")
+        value = self.config
+        for k in keys:
+            if k in value:
+                value = value[k]
+            else:
+                return default
+        return value
+
+    def get_provider_config(self, provider_name: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Get the configuration for a specific provider.
+
+        Args:
+            provider_name: Provider name (if None, use the default provider)
+
+        Returns:
+            Provider configuration
+        """
+        if provider_name is None:
+            provider_name = self.config["model_provider"]
+
+        if provider_name not in self.config:
+            logger.warning(f"Provider '{provider_name}' not found in configuration")
+            return {}
+
+        return self.config[provider_name]
+
+
+# Create a singleton instance
+config = Config()

--- a/Unsiloed/models/__init__.py
+++ b/Unsiloed/models/__init__.py
@@ -1,0 +1,57 @@
+"""
+Model providers package.
+"""
+
+from Unsiloed.models.base import ModelProvider, ModelProviderFactory
+from Unsiloed.models.openai_provider import OpenAIProvider
+
+# Import optional providers
+try:
+    from Unsiloed.models.anthropic_provider import AnthropicProvider
+except ImportError:
+    pass
+
+try:
+    from Unsiloed.models.huggingface_provider import HuggingFaceProvider
+except ImportError:
+    pass
+
+try:
+    from Unsiloed.models.local_provider import LocalLLMProvider
+except ImportError:
+    pass
+
+# Export the factory and base classes
+__all__ = ["ModelProvider", "ModelProviderFactory", "get_provider"]
+
+
+def get_provider(provider_name: str = None, **kwargs):
+    """
+    Get a model provider instance.
+    
+    Args:
+        provider_name: Name of the provider (default: from environment or "openai")
+        **kwargs: Provider-specific configuration
+        
+    Returns:
+        ModelProvider instance
+    """
+    import os
+    import logging
+    
+    logger = logging.getLogger(__name__)
+    
+    # If provider_name is not specified, try to get it from environment
+    if provider_name is None:
+        provider_name = os.environ.get("UNSILOED_MODEL_PROVIDER", "openai")
+        
+    # Get available providers
+    available_providers = ModelProviderFactory.get_available_providers()
+    
+    if provider_name not in available_providers:
+        logger.warning(f"Provider '{provider_name}' not available. Available providers: {available_providers}")
+        logger.info(f"Falling back to OpenAI provider")
+        provider_name = "openai"
+        
+    # Create the provider
+    return ModelProviderFactory.create_provider(provider_name, **kwargs)

--- a/Unsiloed/models/anthropic_provider.py
+++ b/Unsiloed/models/anthropic_provider.py
@@ -1,0 +1,224 @@
+"""
+Anthropic model provider implementation.
+"""
+
+import os
+import json
+import base64
+from typing import Dict, List, Any, Optional, Union
+import logging
+import requests
+from io import BytesIO
+
+from Unsiloed.models.base import ModelProvider, ModelProviderFactory
+
+logger = logging.getLogger(__name__)
+
+# Check if anthropic package is available
+try:
+    import anthropic
+    ANTHROPIC_AVAILABLE = True
+except ImportError:
+    ANTHROPIC_AVAILABLE = False
+    logger.warning("Anthropic package not available. Install with 'pip install anthropic'")
+
+
+class AnthropicProvider(ModelProvider):
+    """
+    Anthropic model provider implementation.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: str = "claude-3-opus-20240229",
+        timeout: float = 60.0,
+        max_retries: int = 3,
+        **kwargs
+    ):
+        """
+        Initialize the Anthropic provider.
+
+        Args:
+            api_key: Anthropic API key (if None, will try to get from environment)
+            model: Model to use (default: claude-3-opus-20240229)
+            timeout: Timeout for API calls in seconds
+            max_retries: Maximum number of retries for API calls
+            **kwargs: Additional provider-specific configuration
+        """
+        if not ANTHROPIC_AVAILABLE:
+            raise ImportError(
+                "Anthropic package not available. Install with 'pip install anthropic'"
+            )
+            
+        self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not self.api_key:
+            logger.error("Anthropic API key not provided and not found in environment")
+            raise ValueError("Anthropic API key is required")
+
+        self.model = model
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.client = None
+
+    def get_client(self):
+        """
+        Get the Anthropic client.
+
+        Returns:
+            Anthropic client instance
+        """
+        if self.client is None:
+            logger.debug("Creating new Anthropic client")
+            self.client = anthropic.Anthropic(
+                api_key=self.api_key,
+                timeout=self.timeout,
+            )
+            
+        return self.client
+
+    def generate_text(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        max_tokens: int = 4000,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> str:
+        """
+        Generate text using the Anthropic model.
+
+        Args:
+            prompt: The prompt to send to the model
+            system_prompt: System prompt for the model
+            max_tokens: Maximum number of tokens to generate
+            temperature: Temperature for generation (0.0 = deterministic)
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated text
+        """
+        client = self.get_client()
+        
+        try:
+            message = client.messages.create(
+                model=self.model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                system=system_prompt if system_prompt else "",
+                messages=[
+                    {"role": "user", "content": prompt}
+                ],
+                **kwargs
+            )
+            
+            return message.content[0].text
+        except Exception as e:
+            logger.error(f"Error generating text with Anthropic: {str(e)}")
+            raise
+
+    def generate_structured_output(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        output_schema: Dict[str, Any] = None,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """
+        Generate structured output (JSON) using the Anthropic model.
+
+        Args:
+            prompt: The prompt to send to the model
+            system_prompt: System prompt for the model
+            output_schema: Schema for the expected output
+            temperature: Temperature for generation (0.0 = deterministic)
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated structured output as a dictionary
+        """
+        # Anthropic doesn't have a native JSON mode like OpenAI,
+        # so we need to instruct it to return JSON in the prompt
+        
+        if output_schema:
+            schema_str = json.dumps(output_schema, indent=2)
+            json_instruction = f"Return your response as a JSON object with the following schema:\n{schema_str}\n\nYour response should be valid JSON and nothing else."
+        else:
+            json_instruction = "Return your response as a valid JSON object and nothing else."
+        
+        enhanced_prompt = f"{prompt}\n\n{json_instruction}"
+        
+        if system_prompt:
+            enhanced_system_prompt = f"{system_prompt} You must return your response as valid JSON and nothing else."
+        else:
+            enhanced_system_prompt = "You must return your response as valid JSON and nothing else."
+        
+        try:
+            response_text = self.generate_text(
+                prompt=enhanced_prompt,
+                system_prompt=enhanced_system_prompt,
+                temperature=temperature,
+                **kwargs
+            )
+            
+            # Extract JSON from the response
+            # Sometimes the model might include markdown code block markers
+            if "```json" in response_text:
+                json_text = response_text.split("```json")[1].split("```")[0].strip()
+            elif "```" in response_text:
+                json_text = response_text.split("```")[1].strip()
+            else:
+                json_text = response_text.strip()
+            
+            return json.loads(json_text)
+        except Exception as e:
+            logger.error(f"Error generating structured output with Anthropic: {str(e)}")
+            raise
+
+    def process_image(
+        self, image_path: str, prompt: str, **kwargs
+    ) -> str:
+        """
+        Process an image using the Anthropic model.
+
+        Args:
+            image_path: Path to the image file
+            prompt: Prompt to send with the image
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated text from the image
+        """
+        client = self.get_client()
+        
+        try:
+            # Read the image file
+            with open(image_path, "rb") as f:
+                image_data = f.read()
+            
+            # Create a message with the image
+            message = client.messages.create(
+                model=self.model,
+                max_tokens=kwargs.get("max_tokens", 4000),
+                temperature=kwargs.get("temperature", 0.0),
+                system=kwargs.get("system_prompt", ""),
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": prompt},
+                            {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": base64.b64encode(image_data).decode("utf-8")}}
+                        ]
+                    }
+                ]
+            )
+            
+            return message.content[0].text
+        except Exception as e:
+            logger.error(f"Error processing image with Anthropic: {str(e)}")
+            raise
+
+
+# Register the Anthropic provider with the factory
+ModelProviderFactory.register_provider("anthropic", AnthropicProvider)

--- a/Unsiloed/models/base.py
+++ b/Unsiloed/models/base.py
@@ -1,0 +1,151 @@
+"""
+Base classes for model providers.
+This module defines the abstract interfaces that all model providers must implement.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Any, Optional, Union
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ModelProvider(ABC):
+    """
+    Abstract base class for model providers.
+    All model providers must implement these methods.
+    """
+
+    @abstractmethod
+    def __init__(self, api_key: Optional[str] = None, **kwargs):
+        """
+        Initialize the model provider.
+
+        Args:
+            api_key: API key for the provider (if required)
+            **kwargs: Additional provider-specific configuration
+        """
+        pass
+
+    @abstractmethod
+    def get_client(self):
+        """
+        Get the client for the model provider.
+
+        Returns:
+            The client object for the provider
+        """
+        pass
+
+    @abstractmethod
+    def generate_text(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        max_tokens: int = 4000,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> str:
+        """
+        Generate text using the model.
+
+        Args:
+            prompt: The prompt to send to the model
+            system_prompt: Optional system prompt for models that support it
+            max_tokens: Maximum number of tokens to generate
+            temperature: Temperature for generation (0.0 = deterministic)
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated text
+        """
+        pass
+
+    @abstractmethod
+    def generate_structured_output(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        output_schema: Dict[str, Any] = None,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """
+        Generate structured output (JSON) using the model.
+
+        Args:
+            prompt: The prompt to send to the model
+            system_prompt: Optional system prompt for models that support it
+            output_schema: Schema for the expected output
+            temperature: Temperature for generation (0.0 = deterministic)
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated structured output as a dictionary
+        """
+        pass
+
+    @abstractmethod
+    def process_image(
+        self, image_path: str, prompt: str, **kwargs
+    ) -> str:
+        """
+        Process an image using the model.
+
+        Args:
+            image_path: Path to the image file
+            prompt: Prompt to send with the image
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated text from the image
+        """
+        pass
+
+
+class ModelProviderFactory:
+    """
+    Factory class for creating model providers.
+    """
+
+    _providers = {}
+
+    @classmethod
+    def register_provider(cls, name: str, provider_class):
+        """
+        Register a model provider.
+
+        Args:
+            name: Name of the provider
+            provider_class: Provider class
+        """
+        cls._providers[name] = provider_class
+        logger.info(f"Registered model provider: {name}")
+
+    @classmethod
+    def create_provider(cls, name: str, **kwargs) -> ModelProvider:
+        """
+        Create a model provider instance.
+
+        Args:
+            name: Name of the provider
+            **kwargs: Provider-specific configuration
+
+        Returns:
+            ModelProvider instance
+        """
+        if name not in cls._providers:
+            raise ValueError(f"Unknown model provider: {name}")
+
+        logger.info(f"Creating model provider: {name}")
+        return cls._providers[name](**kwargs)
+
+    @classmethod
+    def get_available_providers(cls) -> List[str]:
+        """
+        Get a list of available providers.
+
+        Returns:
+            List of provider names
+        """
+        return list(cls._providers.keys())

--- a/Unsiloed/models/huggingface_provider.py
+++ b/Unsiloed/models/huggingface_provider.py
@@ -1,0 +1,273 @@
+"""
+Hugging Face model provider implementation.
+"""
+
+import os
+import json
+import base64
+from typing import Dict, List, Any, Optional, Union
+import logging
+import requests
+from io import BytesIO
+
+from Unsiloed.models.base import ModelProvider, ModelProviderFactory
+
+logger = logging.getLogger(__name__)
+
+
+class HuggingFaceProvider(ModelProvider):
+    """
+    Hugging Face model provider implementation.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: str = "mistralai/Mistral-7B-Instruct-v0.2",
+        api_url: Optional[str] = None,
+        timeout: float = 60.0,
+        **kwargs
+    ):
+        """
+        Initialize the Hugging Face provider.
+
+        Args:
+            api_key: Hugging Face API key (if None, will try to get from environment)
+            model: Model to use (default: mistralai/Mistral-7B-Instruct-v0.2)
+            api_url: API URL (if None, will use the Hugging Face Inference API)
+            timeout: Timeout for API calls in seconds
+            **kwargs: Additional provider-specific configuration
+        """
+        self.api_key = api_key or os.environ.get("HUGGINGFACE_API_KEY")
+        if not self.api_key:
+            logger.error("Hugging Face API key not provided and not found in environment")
+            raise ValueError("Hugging Face API key is required")
+
+        self.model = model
+        self.timeout = timeout
+        
+        # If api_url is provided, use it; otherwise, use the Hugging Face Inference API
+        self.api_url = api_url or f"https://api-inference.huggingface.co/models/{model}"
+        
+        # Check if transformers is available for local inference
+        try:
+            import transformers
+            self.transformers_available = True
+        except ImportError:
+            self.transformers_available = False
+            logger.warning("Transformers package not available. Install with 'pip install transformers'")
+        
+        self.client = None
+        self.local_model = None
+
+    def get_client(self):
+        """
+        Get the Hugging Face client.
+        For Hugging Face, this is just the API key and URL.
+
+        Returns:
+            Dictionary with API key and URL
+        """
+        if self.client is None:
+            self.client = {
+                "api_key": self.api_key,
+                "api_url": self.api_url
+            }
+        return self.client
+
+    def _call_hf_api(self, payload):
+        """
+        Call the Hugging Face Inference API.
+
+        Args:
+            payload: Payload to send to the API
+
+        Returns:
+            API response
+        """
+        client = self.get_client()
+        headers = {"Authorization": f"Bearer {client['api_key']}"}
+        
+        try:
+            response = requests.post(
+                client["api_url"],
+                headers=headers,
+                json=payload,
+                timeout=self.timeout
+            )
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            logger.error(f"Error calling Hugging Face API: {str(e)}")
+            raise
+
+    def generate_text(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        max_tokens: int = 4000,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> str:
+        """
+        Generate text using the Hugging Face model.
+
+        Args:
+            prompt: The prompt to send to the model
+            system_prompt: System prompt for the model
+            max_tokens: Maximum number of tokens to generate
+            temperature: Temperature for generation (0.0 = deterministic)
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated text
+        """
+        # Combine system prompt and user prompt if both are provided
+        if system_prompt:
+            full_prompt = f"{system_prompt}\n\n{prompt}"
+        else:
+            full_prompt = prompt
+        
+        # Prepare the payload
+        payload = {
+            "inputs": full_prompt,
+            "parameters": {
+                "max_new_tokens": max_tokens,
+                "temperature": temperature,
+                **kwargs
+            }
+        }
+        
+        try:
+            response = self._call_hf_api(payload)
+            
+            # Handle different response formats
+            if isinstance(response, list) and len(response) > 0:
+                if "generated_text" in response[0]:
+                    return response[0]["generated_text"]
+                else:
+                    return str(response[0])
+            elif isinstance(response, dict) and "generated_text" in response:
+                return response["generated_text"]
+            else:
+                return str(response)
+        except Exception as e:
+            logger.error(f"Error generating text with Hugging Face: {str(e)}")
+            raise
+
+    def generate_structured_output(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        output_schema: Dict[str, Any] = None,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """
+        Generate structured output (JSON) using the Hugging Face model.
+
+        Args:
+            prompt: The prompt to send to the model
+            system_prompt: System prompt for the model
+            output_schema: Schema for the expected output
+            temperature: Temperature for generation (0.0 = deterministic)
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated structured output as a dictionary
+        """
+        # Hugging Face models don't have native JSON mode,
+        # so we need to instruct the model to return JSON
+        
+        if output_schema:
+            schema_str = json.dumps(output_schema, indent=2)
+            json_instruction = f"Return your response as a JSON object with the following schema:\n{schema_str}\n\nYour response should be valid JSON and nothing else."
+        else:
+            json_instruction = "Return your response as a valid JSON object and nothing else."
+        
+        enhanced_prompt = f"{prompt}\n\n{json_instruction}"
+        
+        if system_prompt:
+            enhanced_system_prompt = f"{system_prompt} You must return your response as valid JSON and nothing else."
+        else:
+            enhanced_system_prompt = "You must return your response as valid JSON and nothing else."
+        
+        try:
+            response_text = self.generate_text(
+                prompt=enhanced_prompt,
+                system_prompt=enhanced_system_prompt,
+                temperature=temperature,
+                **kwargs
+            )
+            
+            # Extract JSON from the response
+            # Sometimes the model might include markdown code block markers
+            if "```json" in response_text:
+                json_text = response_text.split("```json")[1].split("```")[0].strip()
+            elif "```" in response_text:
+                json_text = response_text.split("```")[1].strip()
+            else:
+                json_text = response_text.strip()
+            
+            return json.loads(json_text)
+        except Exception as e:
+            logger.error(f"Error generating structured output with Hugging Face: {str(e)}")
+            raise
+
+    def process_image(
+        self, image_path: str, prompt: str, **kwargs
+    ) -> str:
+        """
+        Process an image using the Hugging Face model.
+
+        Args:
+            image_path: Path to the image file
+            prompt: Prompt to send with the image
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated text from the image
+        """
+        # For image processing, we need to use a multimodal model
+        # Check if the model is a multimodal model
+        if not any(mm_model in self.model.lower() for mm_model in ["llava", "idefics", "blip", "vit"]):
+            logger.warning(f"Model {self.model} may not be a multimodal model capable of processing images")
+        
+        try:
+            # Read the image file
+            with open(image_path, "rb") as f:
+                image_data = f.read()
+            
+            # Encode the image to base64
+            encoded_image = base64.b64encode(image_data).decode("utf-8")
+            
+            # Prepare the payload
+            payload = {
+                "inputs": {
+                    "image": encoded_image,
+                    "prompt": prompt
+                },
+                "parameters": {
+                    **kwargs
+                }
+            }
+            
+            response = self._call_hf_api(payload)
+            
+            # Handle different response formats
+            if isinstance(response, list) and len(response) > 0:
+                if "generated_text" in response[0]:
+                    return response[0]["generated_text"]
+                else:
+                    return str(response[0])
+            elif isinstance(response, dict) and "generated_text" in response:
+                return response["generated_text"]
+            else:
+                return str(response)
+        except Exception as e:
+            logger.error(f"Error processing image with Hugging Face: {str(e)}")
+            raise
+
+
+# Register the Hugging Face provider with the factory
+ModelProviderFactory.register_provider("huggingface", HuggingFaceProvider)

--- a/Unsiloed/models/local_provider.py
+++ b/Unsiloed/models/local_provider.py
@@ -1,0 +1,240 @@
+"""
+Local LLM provider implementation using llama.cpp.
+"""
+
+import os
+import json
+import base64
+from typing import Dict, List, Any, Optional, Union
+import logging
+import subprocess
+import tempfile
+import requests
+from pathlib import Path
+
+from Unsiloed.models.base import ModelProvider, ModelProviderFactory
+
+logger = logging.getLogger(__name__)
+
+# Check if llama-cpp-python package is available
+try:
+    from llama_cpp import Llama
+    LLAMA_CPP_AVAILABLE = True
+except ImportError:
+    LLAMA_CPP_AVAILABLE = False
+    logger.warning("llama-cpp-python package not available. Install with 'pip install llama-cpp-python'")
+
+
+class LocalLLMProvider(ModelProvider):
+    """
+    Local LLM provider implementation using llama.cpp.
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        n_ctx: int = 2048,
+        n_gpu_layers: int = -1,  # -1 means use all available GPU layers
+        verbose: bool = False,
+        **kwargs
+    ):
+        """
+        Initialize the Local LLM provider.
+
+        Args:
+            model_path: Path to the model file
+            n_ctx: Context size
+            n_gpu_layers: Number of GPU layers to use (-1 = all)
+            verbose: Whether to enable verbose output
+            **kwargs: Additional provider-specific configuration
+        """
+        if not LLAMA_CPP_AVAILABLE:
+            raise ImportError(
+                "llama-cpp-python package not available. Install with 'pip install llama-cpp-python'"
+            )
+            
+        self.model_path = model_path
+        if not os.path.exists(model_path):
+            logger.error(f"Model file not found: {model_path}")
+            raise FileNotFoundError(f"Model file not found: {model_path}")
+            
+        self.n_ctx = n_ctx
+        self.n_gpu_layers = n_gpu_layers
+        self.verbose = verbose
+        self.kwargs = kwargs
+        self.client = None
+
+    def get_client(self):
+        """
+        Get the llama.cpp client.
+
+        Returns:
+            Llama instance
+        """
+        if self.client is None:
+            logger.debug(f"Loading model from {self.model_path}")
+            try:
+                self.client = Llama(
+                    model_path=self.model_path,
+                    n_ctx=self.n_ctx,
+                    n_gpu_layers=self.n_gpu_layers,
+                    verbose=self.verbose,
+                    **self.kwargs
+                )
+                logger.debug("Model loaded successfully")
+            except Exception as e:
+                logger.error(f"Error loading model: {str(e)}")
+                raise
+                
+        return self.client
+
+    def generate_text(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        max_tokens: int = 4000,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> str:
+        """
+        Generate text using the local LLM.
+
+        Args:
+            prompt: The prompt to send to the model
+            system_prompt: System prompt for the model
+            max_tokens: Maximum number of tokens to generate
+            temperature: Temperature for generation (0.0 = deterministic)
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated text
+        """
+        client = self.get_client()
+        
+        # Combine system prompt and user prompt if both are provided
+        if system_prompt:
+            # Format depends on the model type, this is a common format
+            full_prompt = f"<s>[INST] {system_prompt}\n\n{prompt} [/INST]"
+        else:
+            # Basic prompt format for Llama models
+            full_prompt = f"<s>[INST] {prompt} [/INST]"
+        
+        try:
+            output = client.create_completion(
+                prompt=full_prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                **kwargs
+            )
+            
+            # Extract the generated text
+            if "choices" in output and len(output["choices"]) > 0:
+                return output["choices"][0]["text"]
+            else:
+                return ""
+        except Exception as e:
+            logger.error(f"Error generating text with local LLM: {str(e)}")
+            raise
+
+    def generate_structured_output(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        output_schema: Dict[str, Any] = None,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """
+        Generate structured output (JSON) using the local LLM.
+
+        Args:
+            prompt: The prompt to send to the model
+            system_prompt: System prompt for the model
+            output_schema: Schema for the expected output
+            temperature: Temperature for generation (0.0 = deterministic)
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated structured output as a dictionary
+        """
+        # Local LLMs don't have native JSON mode,
+        # so we need to instruct the model to return JSON
+        
+        if output_schema:
+            schema_str = json.dumps(output_schema, indent=2)
+            json_instruction = f"Return your response as a JSON object with the following schema:\n{schema_str}\n\nYour response should be valid JSON and nothing else."
+        else:
+            json_instruction = "Return your response as a valid JSON object and nothing else."
+        
+        enhanced_prompt = f"{prompt}\n\n{json_instruction}"
+        
+        if system_prompt:
+            enhanced_system_prompt = f"{system_prompt} You must return your response as valid JSON and nothing else."
+        else:
+            enhanced_system_prompt = "You must return your response as valid JSON and nothing else."
+        
+        try:
+            response_text = self.generate_text(
+                prompt=enhanced_prompt,
+                system_prompt=enhanced_system_prompt,
+                temperature=temperature,
+                **kwargs
+            )
+            
+            # Extract JSON from the response
+            # Sometimes the model might include markdown code block markers
+            if "```json" in response_text:
+                json_text = response_text.split("```json")[1].split("```")[0].strip()
+            elif "```" in response_text:
+                json_text = response_text.split("```")[1].strip()
+            else:
+                json_text = response_text.strip()
+            
+            return json.loads(json_text)
+        except Exception as e:
+            logger.error(f"Error generating structured output with local LLM: {str(e)}")
+            raise
+
+    def process_image(
+        self, image_path: str, prompt: str, **kwargs
+    ) -> str:
+        """
+        Process an image using the local LLM.
+
+        Args:
+            image_path: Path to the image file
+            prompt: Prompt to send with the image
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated text from the image
+        """
+        # Check if this is a multimodal model
+        if not any(mm_model in self.model_path.lower() for mm_model in ["llava", "bakllava", "multimodal"]):
+            logger.error(f"Model {self.model_path} is not a multimodal model capable of processing images")
+            raise ValueError(f"Model {self.model_path} is not a multimodal model capable of processing images")
+        
+        try:
+            # For multimodal models in llama.cpp, we need to use the image_path parameter
+            client = self.get_client()
+            
+            output = client.create_completion(
+                prompt=prompt,
+                image_path=image_path,
+                max_tokens=kwargs.get("max_tokens", 4000),
+                temperature=kwargs.get("temperature", 0.0),
+                **kwargs
+            )
+            
+            # Extract the generated text
+            if "choices" in output and len(output["choices"]) > 0:
+                return output["choices"][0]["text"]
+            else:
+                return ""
+        except Exception as e:
+            logger.error(f"Error processing image with local LLM: {str(e)}")
+            raise
+
+
+# Register the Local LLM provider with the factory
+ModelProviderFactory.register_provider("local", LocalLLMProvider)

--- a/Unsiloed/models/openai_provider.py
+++ b/Unsiloed/models/openai_provider.py
@@ -1,0 +1,237 @@
+"""
+OpenAI model provider implementation.
+"""
+
+import os
+import json
+import base64
+from typing import Dict, List, Any, Optional, Union
+import logging
+from openai import OpenAI
+import numpy as np
+import cv2
+
+from Unsiloed.models.base import ModelProvider, ModelProviderFactory
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIProvider(ModelProvider):
+    """
+    OpenAI model provider implementation.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: str = "gpt-4o",
+        timeout: float = 60.0,
+        max_retries: int = 3,
+        **kwargs
+    ):
+        """
+        Initialize the OpenAI provider.
+
+        Args:
+            api_key: OpenAI API key (if None, will try to get from environment)
+            model: Model to use (default: gpt-4o)
+            timeout: Timeout for API calls in seconds
+            max_retries: Maximum number of retries for API calls
+            **kwargs: Additional provider-specific configuration
+        """
+        self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not self.api_key:
+            logger.error("OpenAI API key not provided and not found in environment")
+            raise ValueError("OpenAI API key is required")
+
+        self.model = model
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.client = None
+
+    def get_client(self):
+        """
+        Get the OpenAI client.
+
+        Returns:
+            OpenAI client instance
+        """
+        if self.client is None:
+            logger.debug("Creating new OpenAI client")
+            self.client = OpenAI(
+                api_key=self.api_key,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+            )
+            
+            # Test the client by listing available models
+            try:
+                models = self.client.models.list()
+                if models and hasattr(models, "data") and len(models.data) > 0:
+                    logger.debug(
+                        f"OpenAI client initialized successfully, available models: {len(models.data)}"
+                    )
+                else:
+                    logger.warning("OpenAI client initialized but returned no models")
+            except Exception as e:
+                logger.error(f"Error testing OpenAI client: {str(e)}")
+                
+        return self.client
+
+    def generate_text(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        max_tokens: int = 4000,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> str:
+        """
+        Generate text using the OpenAI model.
+
+        Args:
+            prompt: The prompt to send to the model
+            system_prompt: System prompt for the model
+            max_tokens: Maximum number of tokens to generate
+            temperature: Temperature for generation (0.0 = deterministic)
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated text
+        """
+        client = self.get_client()
+        
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        
+        messages.append({"role": "user", "content": prompt})
+        
+        try:
+            response = client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                **kwargs
+            )
+            
+            return response.choices[0].message.content
+        except Exception as e:
+            logger.error(f"Error generating text with OpenAI: {str(e)}")
+            raise
+
+    def generate_structured_output(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        output_schema: Dict[str, Any] = None,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """
+        Generate structured output (JSON) using the OpenAI model.
+
+        Args:
+            prompt: The prompt to send to the model
+            system_prompt: System prompt for the model
+            output_schema: Schema for the expected output
+            temperature: Temperature for generation (0.0 = deterministic)
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated structured output as a dictionary
+        """
+        client = self.get_client()
+        
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        
+        messages.append({"role": "user", "content": prompt})
+        
+        try:
+            response = client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                response_format={"type": "json_object"},
+                temperature=temperature,
+                **kwargs
+            )
+            
+            content = response.choices[0].message.content
+            return json.loads(content)
+        except Exception as e:
+            logger.error(f"Error generating structured output with OpenAI: {str(e)}")
+            raise
+
+    def encode_image_to_base64(self, image_path):
+        """
+        Encode an image to base64.
+
+        Args:
+            image_path: Path to the image file or numpy array
+
+        Returns:
+            Base64 encoded string of the image
+        """
+        logger.debug("Encoding image to base64")
+
+        # Handle numpy array (from CV2)
+        if isinstance(image_path, np.ndarray):
+            success, buffer = cv2.imencode(".jpg", image_path)
+            if not success:
+                raise ValueError("Failed to encode image")
+            return base64.b64encode(buffer).decode("utf-8")
+
+        # Handle file path
+        with open(image_path, "rb") as image_file:
+            return base64.b64encode(image_file.read()).decode("utf-8")
+
+    def process_image(
+        self, image_path: str, prompt: str, **kwargs
+    ) -> str:
+        """
+        Process an image using the OpenAI model.
+
+        Args:
+            image_path: Path to the image file
+            prompt: Prompt to send with the image
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            Generated text from the image
+        """
+        client = self.get_client()
+        
+        # Encode the image to base64
+        base64_image = self.encode_image_to_base64(image_path)
+        
+        try:
+            response = client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": prompt},
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": f"data:image/jpeg;base64,{base64_image}"
+                                },
+                            },
+                        ],
+                    }
+                ],
+                **kwargs
+            )
+            
+            return response.choices[0].message.content
+        except Exception as e:
+            logger.error(f"Error processing image with OpenAI: {str(e)}")
+            raise
+
+
+# Register the OpenAI provider with the factory
+ModelProviderFactory.register_provider("openai", OpenAIProvider)

--- a/Unsiloed/services/chunking.py
+++ b/Unsiloed/services/chunking.py
@@ -5,7 +5,7 @@ from Unsiloed.utils.chunking import (
     heading_chunking,
     semantic_chunking,
 )
-from Unsiloed.utils.openai import (
+from Unsiloed.utils.model_utils import (
     extract_text_from_pdf,
     extract_text_from_docx,
     extract_text_from_pptx,
@@ -22,6 +22,7 @@ def process_document_chunking(
     strategy,
     chunk_size=1000,
     overlap=100,
+    provider_name=None,
 ):
     """
     Process a document file (PDF, DOCX, PPTX) with the specified chunking strategy.
@@ -32,12 +33,13 @@ def process_document_chunking(
         strategy: Chunking strategy to use
         chunk_size: Size of chunks for fixed strategy
         overlap: Overlap size for fixed strategy
+        provider_name: Name of the model provider to use (default: from config)
 
     Returns:
         Dictionary with chunking results
     """
     logger.info(
-        f"Processing {file_type.upper()} document with {strategy} chunking strategy"
+        f"Processing {file_type.upper()} document with {strategy} chunking strategy using provider: {provider_name or 'default'}"
     )
 
     # Handle page-based chunking for PDFs only
@@ -58,7 +60,7 @@ def process_document_chunking(
         if strategy == "fixed":
             chunks = fixed_size_chunking(text, chunk_size, overlap)
         elif strategy == "semantic":
-            chunks = semantic_chunking(text)
+            chunks = semantic_chunking(text, provider_name)
         elif strategy == "paragraph":
             chunks = paragraph_chunking(text)
         elif strategy == "heading":
@@ -85,6 +87,7 @@ def process_document_chunking(
         "strategy": strategy,
         "total_chunks": total_chunks,
         "avg_chunk_size": avg_chunk_size,
+        "model_provider": provider_name or "default",
         "chunks": chunks,
     }
 

--- a/Unsiloed/utils/chunking.py
+++ b/Unsiloed/utils/chunking.py
@@ -2,7 +2,7 @@ import concurrent.futures
 from typing import Literal
 import logging
 import PyPDF2
-from Unsiloed.utils.openai import (
+from Unsiloed.utils.model_utils import (
     semantic_chunk_with_structured_output,
 )
 
@@ -195,15 +195,16 @@ def heading_chunking(text):
     return chunks
 
 
-def semantic_chunking(text):
+def semantic_chunking(text, provider_name=None):
     """
-    Use OpenAI to identify semantic chunks in the text.
+    Use the selected model provider to identify semantic chunks in the text.
 
     Args:
         text: The text to chunk
+        provider_name: Name of the model provider to use (default: from config)
 
     Returns:
         List of chunks with metadata
     """
     # Use the optimized semantic chunking with Structured Outputs
-    return semantic_chunk_with_structured_output(text)
+    return semantic_chunk_with_structured_output(text, provider_name)

--- a/Unsiloed/utils/model_utils.py
+++ b/Unsiloed/utils/model_utils.py
@@ -1,0 +1,385 @@
+"""
+Model-agnostic utilities for OCR and text processing.
+This module provides functions for working with different model providers.
+"""
+
+import os
+import base64
+import json
+from typing import List, Dict, Any, Optional
+import logging
+import concurrent.futures
+import PyPDF2
+from dotenv import load_dotenv
+import numpy as np
+import cv2
+
+from Unsiloed.models import get_provider
+from Unsiloed.config import config
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+
+def encode_image_to_base64(image_path):
+    """
+    Encode an image to base64.
+
+    Args:
+        image_path: Path to the image file or numpy array
+
+    Returns:
+        Base64 encoded string of the image
+    """
+    logger.debug("Encoding image to base64")
+
+    # Handle numpy array (from CV2)
+    if isinstance(image_path, np.ndarray):
+        success, buffer = cv2.imencode(".jpg", image_path)
+        if not success:
+            raise ValueError("Failed to encode image")
+        return base64.b64encode(buffer).decode("utf-8")
+
+    # Handle file path
+    with open(image_path, "rb") as image_file:
+        return base64.b64encode(image_file.read()).decode("utf-8")
+
+
+def create_extraction_prompt(schema: Dict[str, Any], page_count: int) -> str:
+    """
+    Create a prompt instructing the model how to extract data according to the schema.
+
+    Args:
+        schema: JSON schema defining the structure
+        page_count: Number of pages in the document
+
+    Returns:
+        Prompt string for the model
+    """
+    # Create a compact JSON representation of the schema
+    schema_str = json.dumps(schema, indent=2)
+
+    prompt = f"""
+    You are an expert at extracting structured data from documents.
+    
+    I have a document with {page_count} pages that has been converted to images. I need you to extract specific information from these images according to the following JSON schema:
+    
+    {schema_str}
+    
+    Please follow these instructions carefully:
+    
+    1. Examine all {page_count} images thoroughly to find the requested information.
+    2. Extract the exact text from the document that matches each field in the schema.
+    3. If you cannot find information for a specific field in any of the pages, return an empty string or null value for that field.
+    4. For array fields, include all instances found throughout the document.
+    5. Maintain the structure defined in the schema exactly.
+    6. Return only the extracted data as a valid JSON object, matching the structure of the schema.
+    7. Do not add any explanatory text or notes outside the JSON structure.
+    8. Be precise and accurate in your extraction.
+    9. If text is unclear or ambiguous, make your best guess based on context.
+    10. For dates, numbers, and other formatted data, maintain the format as shown in the document.
+    11. IMPORTANT: Your response MUST be a valid JSON object that exactly matches the structure of the provided schema.
+    12. IMPORTANT: Do not include any explanations, just return the JSON object.
+    
+    Your response should be a valid JSON object containing only the extracted data.
+    """
+
+    return prompt
+
+
+def semantic_chunk_with_structured_output(text: str, provider_name: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    Use the selected model provider to create semantic chunks from text.
+
+    Args:
+        text: The text to chunk
+        provider_name: Name of the model provider to use (default: from config)
+
+    Returns:
+        List of chunks with metadata
+    """
+    # If text is too long, split it first using a simpler method
+    # and then process each part in parallel
+    if len(text) > 25000:
+        logger.info(
+            "Text too long for direct semantic chunking, applying parallel processing"
+        )
+        return process_long_text_semantically(text, provider_name)
+
+    try:
+        # Get the model provider
+        provider_config = config.get_provider_config(provider_name)
+        model_provider = get_provider(provider_name, **provider_config)
+
+        # Create a system prompt for the model
+        system_prompt = "You are an expert at analyzing and dividing text into meaningful semantic chunks. Your output should be valid JSON."
+        
+        # Define the output schema
+        output_schema = {
+            "chunks": [
+                {
+                    "text": "the text of the chunk",
+                    "title": "a descriptive title for this chunk",
+                    "position": "beginning/middle/end"
+                }
+            ]
+        }
+        
+        # Create the user prompt
+        user_prompt = f"""Please analyze the following text and divide it into logical semantic chunks. 
+        Each chunk should represent a cohesive unit of information or a distinct section.
+        
+        Text to chunk:
+        
+        {text}"""
+        
+        # Generate structured output using the model provider
+        result = model_provider.generate_structured_output(
+            prompt=user_prompt,
+            system_prompt=system_prompt,
+            output_schema=output_schema,
+            temperature=0.1
+        )
+
+        # Convert the response to our standard chunk format
+        chunks = []
+        current_position = 0
+
+        for i, chunk_data in enumerate(result.get("chunks", [])):
+            chunk_text = chunk_data.get("text", "")
+            # Find the chunk in the original text to get accurate character positions
+            start_position = text.find(chunk_text, current_position)
+            if start_position == -1:
+                # If exact match not found, use approximate position
+                start_position = current_position
+
+            end_position = start_position + len(chunk_text)
+
+            chunks.append(
+                {
+                    "text": chunk_text,
+                    "metadata": {
+                        "title": chunk_data.get("title", f"Chunk {i + 1}"),
+                        "position": chunk_data.get("position", "unknown"),
+                        "start_char": start_position,
+                        "end_char": end_position,
+                        "strategy": "semantic",
+                    },
+                }
+            )
+
+            current_position = end_position
+
+        return chunks
+
+    except Exception as e:
+        logger.error(f"Error in semantic chunking with model provider: {str(e)}")
+        # Fall back to paragraph chunking if semantic chunking fails
+        logger.info("Falling back to paragraph chunking")
+        # We'll just do basic paragraph chunking here
+        paragraphs = text.split("\n\n")
+        paragraphs = [p.strip() for p in paragraphs if p.strip()]
+
+        chunks = []
+        current_position = 0
+
+        for i, paragraph in enumerate(paragraphs):
+            start_position = text.find(paragraph, current_position)
+            if start_position == -1:
+                start_position = current_position
+
+            end_position = start_position + len(paragraph)
+
+            chunks.append(
+                {
+                    "text": paragraph,
+                    "metadata": {
+                        "title": f"Paragraph {i + 1}",
+                        "position": "unknown",
+                        "start_char": start_position,
+                        "end_char": end_position,
+                        "strategy": "paragraph",  # Fall back strategy
+                    },
+                }
+            )
+
+            current_position = end_position
+
+        return chunks
+
+
+def process_long_text_semantically(text: str, provider_name: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    Process a long text by breaking it into smaller pieces and chunking each piece semantically.
+    Uses parallel processing for better performance.
+
+    Args:
+        text: The long text to process
+        provider_name: Name of the model provider to use (default: from config)
+
+    Returns:
+        List of semantic chunks
+    """
+    # Create chunks of 25000 characters with 500 character overlap
+    text_chunks = []
+    chunk_size = 25000
+    overlap = 500
+    start = 0
+    text_length = len(text)
+
+    while start < text_length:
+        end = min(start + chunk_size, text_length)
+        text_chunks.append(text[start:end])
+        start = end - overlap if end < text_length else text_length
+
+    # Process each chunk in parallel
+    all_semantic_chunks = []
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        # Define a worker function
+        def process_chunk(chunk_text):
+            try:
+                # Process this chunk with the selected model provider
+                sub_chunks = semantic_chunk_with_structured_output(chunk_text, provider_name)
+                return sub_chunks
+            except Exception as e:
+                logger.error(
+                    f"Error processing semantic subchunk: {str(e)}"
+                )
+                return []
+
+        # Submit all tasks and gather results
+        futures = [executor.submit(process_chunk, chunk) for chunk in text_chunks]
+        for future in concurrent.futures.as_completed(futures):
+            all_semantic_chunks.extend(future.result())
+
+    return all_semantic_chunks
+
+
+# Document text extraction functions (moved from openai.py)
+
+def extract_text_from_pdf(pdf_path: str) -> str:
+    """
+    Extract text from a PDF file with optimized performance.
+    Uses parallel processing for multi-page PDFs.
+
+    Args:
+        pdf_path: Path to the PDF file
+
+    Returns:
+        Extracted text from the PDF
+    """
+    try:
+        with open(pdf_path, "rb") as file:
+            reader = PyPDF2.PdfReader(file)
+
+            # Function to extract text from a page
+            def extract_page_text(page_idx):
+                try:
+                    page = reader.pages[page_idx]
+                    text = page.extract_text() or ""
+                    return text
+                except Exception as e:
+                    logger.warning(
+                        f"Error extracting text from page {page_idx}: {str(e)}"
+                    )
+                    return ""
+
+            # For small PDFs, sequential processing is faster
+            if len(reader.pages) <= 5:
+                all_text = ""
+                for i in range(len(reader.pages)):
+                    all_text += extract_page_text(i) + "\n\n"
+            else:
+                # Process pages in parallel for larger PDFs
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    results = list(
+                        executor.map(extract_page_text, range(len(reader.pages)))
+                    )
+                all_text = "\n\n".join(results)
+
+        return all_text
+    except Exception as e:
+        logger.error(f"Error extracting text from PDF: {str(e)}")
+        raise
+
+
+def extract_text_from_docx(docx_path: str) -> str:
+    """
+    Extract text from a DOCX file.
+
+    Args:
+        docx_path: Path to the DOCX file
+
+    Returns:
+        Extracted text from the DOCX
+    """
+    try:
+        import docx  # python-docx package
+
+        doc = docx.Document(docx_path)
+        full_text = []
+
+        # Extract text from paragraphs
+        for para in doc.paragraphs:
+            full_text.append(para.text)
+
+        # Extract text from tables
+        for table in doc.tables:
+            for row in table.rows:
+                for cell in row.cells:
+                    full_text.append(cell.text)
+
+        return "\n\n".join(full_text)
+    except Exception as e:
+        logger.error(f"Error extracting text from DOCX: {str(e)}")
+        raise
+
+
+def extract_text_from_pptx(pptx_path: str) -> str:
+    """
+    Extract text from a PPTX file.
+
+    Args:
+        pptx_path: Path to the PPTX file
+
+    Returns:
+        Extracted text from the PPTX
+    """
+    try:
+        from pptx import Presentation  # python-pptx package
+
+        presentation = Presentation(pptx_path)
+        full_text = []
+
+        # Loop through slides
+        for slide_number, slide in enumerate(presentation.slides, 1):
+            slide_text = []
+            slide_text.append(f"Slide {slide_number}")
+
+            # Extract text from shapes (including text boxes)
+            for shape in slide.shapes:
+                if hasattr(shape, "text") and shape.text:
+                    slide_text.append(shape.text)
+
+                # Extract text from tables
+                if shape.has_table:
+                    for row in shape.table.rows:
+                        row_text = []
+                        for cell in row.cells:
+                            if cell.text:
+                                row_text.append(cell.text)
+                        if row_text:
+                            slide_text.append(" | ".join(row_text))
+
+            full_text.append("\n".join(slide_text))
+
+        return "\n\n".join(full_text)
+    except Exception as e:
+        logger.error(f"Error extracting text from PPTX: {str(e)}")
+        raise

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,19 @@ setup(
         "opencv-python-headless",
         "requests",
     ],
+    extras_require={
+        "all": [
+            "anthropic",
+            "llama-cpp-python",
+            "huggingface_hub",
+        ],
+        "anthropic": ["anthropic"],
+        "local": ["llama-cpp-python"],
+        "huggingface": ["huggingface_hub"],
+    },
     entry_points={
         "console_scripts": [
             "Unsiloed=Unsiloed.cli:main",
         ],
     },
-) 
+)


### PR DESCRIPTION
## Overview
This PR implements support for multiple OCR/LLM models beyond OpenAI, addressing issue #4. The implementation allows users to choose between different model providers (OpenAI, Anthropic, Hugging Face, and local LLMs via llama.cpp) for document processing and semantic chunking.

## Changes Made
 1.Model Provider Infrastructure:
Added a new models package with provider implementations:
base.py: Abstract base classes and factory for model providers
openai_provider.py: OpenAI implementation
anthropic_provider.py: Anthropic Claude implementation
huggingface_provider.py: Hugging Face models implementation
local_provider.py: Local LLM implementation using llama.cpp
Added config.py for centralized configuration management

2.Model-Agnostic Utilities:
Added model_utils.py with model-agnostic implementations of:
Semantic chunking
Document text extraction
Image processing

3. Main Process Updates:
Updated the main process function in Unsiloed/__init__.py to support different model providers and their credentials
Added a new modelProvider parameter to specify which model to use
Enhanced credential handling to support different API keys for different providers

4. Chunking Service Updates:
Modified Unsiloed/services/chunking.py to use model-agnostic functions
Added a provider_name parameter to pass the selected model provider
Updated result metadata to include information about the model provider used
5. Chunking Utilities:
Updated Unsiloed/utils/chunking.py to use model-agnostic semantic chunking
Modified the semantic chunking function to support multiple model providers

6. Dependency Management:
Updated setup.py to add optional dependencies for different model providers:
anthropic for Claude models
huggingface_hub for Hugging Face models
llama-cpp-python for local LLM models

7. Documentation:
Updated README.md with comprehensive documentation for using different model providers
Added examples showing how to use each model provider
Added information about environment variables for different providers
Updated installation instructions to include optional dependencies
##How to Use
Users can now specify which model provider to use:

```
# Using OpenAI
result = Unsiloed.process_sync({
    "filePath": "./document.pdf",
    "credentials": {
        "apiKey": os.environ.get("OPENAI_API_KEY")
    },
    "modelProvider": "openai",
    "strategy": "semantic"
})

# Using Anthropic Claude
result = Unsiloed.process_sync({
    "filePath": "./document.pdf",
    "credentials": {
        "anthropicApiKey": os.environ.get("ANTHROPIC_API_KEY")
    },
    "modelProvider": "anthropic",
    "strategy": "semantic"
})

# Using Hugging Face
result = Unsiloed.process_sync({
    "filePath": "./document.pdf",
    "credentials": {
        "huggingfaceApiKey": os.environ.get("HUGGINGFACE_API_KEY")
    },
    "modelProvider": "huggingface",
    "strategy": "semantic"
})

# Using Local LLM
result = Unsiloed.process_sync({
    "filePath": "./document.pdf",
    "credentials": {
        "localModelPath": os.environ.get("LOCAL_MODEL_PATH")
    },
    "modelProvider": "local",
    "strategy": "semantic"
})

```
Environment Variables
Added support for the following environment variables:

OPENAI_API_KEY: OpenAI API key
ANTHROPIC_API_KEY: Anthropic API key
HUGGINGFACE_API_KEY: Hugging Face API key
LOCAL_MODEL_PATH: Path to local LLM model
UNSILOED_MODEL_PROVIDER: Default model provider
Installation Options
Users can now install with specific model providers:

```
# Basic installation with OpenAI support
pip install unsiloed

# Install with all model providers
pip install unsiloed[all]

# Install with specific model providers
pip install unsiloed[anthropic]  # For Anthropic Claude support
pip install unsiloed[huggingface]  # For Hugging Face models support
pip install unsiloed[local]  # For local LLM support via llama.cpp

```
Testing
The implementation has been tested with:

OpenAI GPT-4o for semantic chunking
Different chunking strategies (fixed, semantic, paragraph, heading, page)
Various document types (PDF, DOCX, PPTX)

Closes #4
/claim #4 