### PR TITLE
added markdown support

### DIFF
--- a/Unsiloed/__init__.py
+++ b/Unsiloed/__init__.py
@@ -2,10 +2,14 @@
 import os
 import tempfile
 import requests
-from Unsiloed.services.chunking import process_document_chunking
+from Unsiloed.services.chunking import process_document_chunking, OutputFormat, MarkdownTemplate, AnnotationModel
 from Unsiloed.utils.chunking import ChunkingStrategy
+from typing import Literal, Dict
+import logging
 
-async def process(options):
+logger = logging.getLogger(__name__)
+
+async def process(options: Dict):
     """
     Process a document file with OCR and chunking capabilities.
     
@@ -16,10 +20,21 @@ async def process(options):
             - strategy (str, optional): Chunking strategy to use (default: "semantic")
             - chunkSize (int, optional): Size of chunks (default: 1000)
             - overlap (int, optional): Overlap size (default: 100)
-    
+            - output_format (str, optional): Output format (json or markdown, default: "json")
+            - use_collapsible (bool, optional): Use collapsible sections in Markdown (default: False)
+            - markdown_template (str, optional): Markdown template style (table, list, compact, nested, default: "table")
+            - metadata_fields (list, optional): Metadata fields to include in Markdown
+            - annotate (bool, optional): Include content-based annotations in Markdown (default: False)
+            - annotation_model (str, optional): OpenAI model for annotations (gpt-4o-mini or gpt-4o, default: "gpt-4o-mini")
+            - download (bool, optional): Return Markdown output as a downloadable file (default: False)
+
     Returns:
-        dict: A dictionary containing the processed chunks and metadata
+        dict or str: Processed chunks and metadata (JSON) or Markdown string
     """
+
+    if not isinstance(options, dict):
+        logger.error(f"Invalid options type: expected dict, got {type(options).__name__}")
+        raise ValueError(f"options must be a dictionary, got {type(options).__name__}")
     # Set the OpenAI API key from credentials
     if "credentials" in options and "apiKey" in options["credentials"]:
         os.environ["OPENAI_API_KEY"] = options["credentials"]["apiKey"]
@@ -33,7 +48,16 @@ async def process(options):
     strategy = options.get("strategy", "semantic")
     chunk_size = options.get("chunkSize", 1000)
     overlap = options.get("overlap", 100)
-    
+    # CHANGED: Added output_format and use_collapsible options
+    output_format: OutputFormat = options.get("output_format", os.environ.get("DEFAULT_OUTPUT_FORMAT", "json"))
+    use_collapsible = options.get("use_collapsible", False),
+    # CHANGED: Added new options
+    markdown_template: MarkdownTemplate = options.get("markdown_template", os.environ.get("DEFAULT_MARKDOWN_TEMPLATE", "table"))
+    metadata_fields = options.get("metadata_fields", None)
+    annotate = options.get("annotate", False)
+    # CHANGED: Added annotation_model option
+    annotation_model: AnnotationModel = options.get("annotation_model", "gpt-4o-mini")
+    download = options.get("download", False)
     # Handle URLs by downloading the file
     temp_file = None
     local_file_path = file_path
@@ -79,7 +103,14 @@ async def process(options):
             file_type,
             strategy,
             chunk_size,
-            overlap
+            overlap,
+            output_format,
+            use_collapsible,
+            markdown_template,
+            metadata_fields,
+            annotate, 
+            annotation_model,
+            download
         )
         
         return result
@@ -90,10 +121,41 @@ async def process(options):
             os.unlink(local_file_path)
 
 # Also provide a synchronous version for simpler usage
-def process_sync(options):
+def process_sync(options: Dict):
     """Synchronous version of the process function"""
     import asyncio
     loop = asyncio.new_event_loop()
-    result = loop.run_until_complete(process(options))
-    loop.close()
-    return result
+    # CHANGED: Added try-except for better error handling
+    try:
+        result = loop.run_until_complete(process(options))
+        return result
+    finally:
+        loop.close()
+
+
+"""
+
+Nested Template with OpenAI Annotations:
+
+curl -X POST "http://localhost:8000/chunking" \
+  -F "document_file=@test.pdf" \
+  -F "strategy=semantic" \
+  -F "output_format=markdown" \
+  -F "markdown_template=nested" \
+  -F "metadata_fields=title,position" \
+  -F "annotate=true" \
+  -F "annotation_model=gpt-4o"
+
+  
+
+
+  Compact Template
+
+  curl -X POST "http://localhost:8000/chunking" \
+  -F "document_file=@test.pdf" \
+  -F "strategy=semantic" \
+  -F "output_format=markdown" \
+  -F "markdown_template=compact"
+
+
+"""

--- a/Unsiloed/config/templates.py
+++ b/Unsiloed/config/templates.py
@@ -1,0 +1,178 @@
+from typing import List, Dict, Any
+
+def table_template(chunks: List[Dict[str, Any]], use_collapsible: bool, metadata_fields: List[str]) -> str:
+    """
+    Generate Markdown output using a table-based template.
+
+    Args:
+        chunks: List of chunk dictionaries with text and metadata
+        use_collapsible: Whether to use collapsible sections
+        metadata_fields: List of metadata fields to include
+
+    Returns:
+        Markdown-formatted string
+    """
+    if not chunks:
+        return "# Document Chunks\n\nNo chunks generated."
+
+    markdown = "# Document Chunks\n\n"
+    markdown += "## Chunk Summary\n\n"
+    markdown += "| Index | Text Preview | Metadata |\n"
+    markdown += "|-------|--------------|----------|\n"
+
+    for i, chunk in enumerate(chunks, 1):
+        text = chunk["text"].replace("\n", " ").strip()[:50] + "..."  # Preview
+        metadata = chunk.get("metadata", {})
+        metadata_str = ", ".join(f"{k}: {v}" for k, v in metadata.items() if k in metadata_fields)
+
+        markdown += f"| {i} | {text} | {metadata_str} |\n"
+
+    markdown += "\n## Chunk Details\n\n"
+
+    for i, chunk in enumerate(chunks, 1):
+        metadata = chunk.get("metadata", {})
+        heading = metadata.get("title") or metadata.get("heading") or f"Chunk {i}"
+        markdown += f"### {heading}\n\n"
+
+        if use_collapsible:
+            markdown += f"<details><summary>{heading}</summary>\n\n"
+            markdown += f"{chunk['text']}\n\n"
+            if metadata.get("strategy") == "semantic" and "position" in metadata_fields and metadata.get("position"):
+                markdown += f"> Position: {metadata['position']}\n\n"
+            markdown += "</details>\n\n"
+        else:
+            markdown += f"{chunk['text']}\n\n"
+            if metadata.get("strategy") == "semantic" and "position" in metadata_fields and metadata.get("position"):
+                markdown += f"> Position: {metadata['position']}\n\n"
+
+    return markdown
+
+def list_template(chunks: List[Dict[str, Any]], use_collapsible: bool, metadata_fields: List[str]) -> str:
+    """
+    Generate Markdown output using a list-based template.
+
+    Args:
+        chunks: List of chunk dictionaries with text and metadata
+        use_collapsible: Whether to use collapsible sections
+        metadata_fields: List of metadata fields to include
+
+    Returns:
+        Markdown-formatted string
+    """
+    if not chunks:
+        return "# Document Chunks\n\nNo chunks generated."
+
+    markdown = "# Document Chunks\n\n"
+    markdown += "## Chunk Summary\n\n"
+
+    for i, chunk in enumerate(chunks, 1):
+        text = chunk["text"].replace("\n", " ").strip()[:50] + "..."  # Preview
+        metadata = chunk.get("metadata", {})
+        metadata_str = ", ".join(f"{k}: {v}" for k, v in metadata.items() if k in metadata_fields)
+        markdown += f"- **Chunk {i}**: {text} ({metadata_str})\n"
+
+    markdown += "\n## Chunk Details\n\n"
+
+    for i, chunk in enumerate(chunks, 1):
+        metadata = chunk.get("metadata", {})
+        heading = metadata.get("title") or metadata.get("heading") or f"Chunk {i}"
+        markdown += f"### {heading}\n\n"
+
+        if use_collapsible:
+            markdown += f"<details><summary>{heading}</summary>\n\n"
+            markdown += f"{chunk['text']}\n\n"
+            if metadata.get("strategy") == "semantic" and "position" in metadata_fields and metadata.get("position"):
+                markdown += f"> Position: {metadata['position']}\n\n"
+            markdown += "</details>\n\n"
+        else:
+            markdown += f"{chunk['text']}\n\n"
+            if metadata.get("strategy") == "semantic" and "position" in metadata_fields and metadata.get("position"):
+                markdown += f"> Position: {metadata['position']}\n\n"
+
+    return markdown
+
+# CHANGED: Added compact template
+def compact_template(chunks: List[Dict[str, Any]], use_collapsible: bool, metadata_fields: List[str]) -> str:
+    """
+    Generate minimal Markdown output with only chunk text and headings.
+
+    Args:
+        chunks: List of chunk dictionaries with text and metadata
+        use_collapsible: Whether to use collapsible sections
+        metadata_fields: Ignored in this template
+
+    Returns:
+        Markdown-formatted string
+    """
+    if not chunks:
+        return "# Document Chunks\n\nNo chunks generated."
+
+    markdown = "# Document Chunks\n\n"
+
+    for i, chunk in enumerate(chunks, 1):
+        metadata = chunk.get("metadata", {})
+        heading = metadata.get("title") or metadata.get("heading") or f"Chunk {i}"
+        markdown += f"### {heading}\n\n"
+
+        if use_collapsible:
+            markdown += f"<details><summary>{heading}</summary>\n\n"
+            markdown += f"{chunk['text']}\n\n"
+            markdown += "</details>\n\n"
+        else:
+            markdown += f"{chunk['text']}\n\n"
+
+    return markdown
+
+# CHANGED: Added nested template
+def nested_template(chunks: List[Dict[str, Any]], use_collapsible: bool, metadata_fields: List[str]) -> str:
+    """
+    Generate Markdown output with nested lists based on chunk position.
+
+    Args:
+        chunks: List of chunk dictionaries with text and metadata
+        use_collapsible: Whether to use collapsible sections
+        metadata_fields: List of metadata fields to include
+
+    Returns:
+        Markdown-formatted string
+    """
+    if not chunks:
+        return "# Document Chunks\n\nNo chunks generated."
+
+    markdown = "# Document Chunks\n\n"
+    markdown += "## Chunk Hierarchy\n\n"
+
+    # Group chunks by position (beginning, middle, end)
+    positions = {"beginning": [], "middle": [], "end": []}
+    for i, chunk in enumerate(chunks, 1):
+        metadata = chunk.get("metadata", {})
+        pos = metadata.get("position", "middle").lower()
+        positions[pos].append((i, chunk, metadata))
+
+    for pos in ["beginning", "middle", "end"]:
+        if positions[pos]:
+            markdown += f"- **{pos.capitalize()}**\n"
+            for i, chunk, metadata in positions[pos]:
+                text = chunk["text"].replace("\n", " ").strip()[:50] + "..."
+                metadata_str = ", ".join(f"{k}: {v}" for k, v in metadata.items() if k in metadata_fields)
+                markdown += f"  - Chunk {i}: {text} ({metadata_str})\n"
+
+    markdown += "\n## Chunk Details\n\n"
+
+    for i, chunk in enumerate(chunks, 1):
+        metadata = chunk.get("metadata", {})
+        heading = metadata.get("title") or metadata.get("heading") or f"Chunk {i}"
+        markdown += f"### {heading}\n\n"
+
+        if use_collapsible:
+            markdown += f"<details><summary>{heading}</summary>\n\n"
+            markdown += f"{chunk['text']}\n\n"
+            if metadata.get("strategy") == "semantic" and "position" in metadata_fields and metadata.get("position"):
+                markdown += f"> Position: {metadata['position']}\n\n"
+            markdown += "</details>\n\n"
+        else:
+            markdown += f"{chunk['text']}\n\n"
+            if metadata.get("strategy") == "semantic" and "position" in metadata_fields and metadata.get("position"):
+                markdown += f"> Position: {metadata['position']}\n\n"
+
+    return markdown

--- a/Unsiloed/routes/chunking_routes.py
+++ b/Unsiloed/routes/chunking_routes.py
@@ -1,10 +1,12 @@
 from fastapi import APIRouter, HTTPException, UploadFile, Form
-from fastapi.responses import JSONResponse
-from Unsiloed.services.chunking import process_document_chunking
+from fastapi.responses import JSONResponse, PlainTextResponse, FileResponse
+from Unsiloed.services.chunking import process_document_chunking, OutputFormat, MarkdownTemplate, AnnotationModel
 from Unsiloed.utils.chunking import ChunkingStrategy
 import os
 import tempfile
 import logging
+import aiofiles
+from starlette.background import BackgroundTask
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +19,17 @@ async def chunk_document(
     strategy: ChunkingStrategy = Form("semantic"),
     chunk_size: int = Form(1000),
     overlap: int = Form(100),
+    # CHANGED: Added output_format and use_collapsible parameters
+    output_format: OutputFormat = Form("json"),
+    use_collapsible: bool = Form(False),
+    # CHANGED: Added new parameters
+    markdown_template: MarkdownTemplate = Form("table"),
+    metadata_fields: str = Form(None),  # Comma-separated string
+    annotate: bool = Form(False),
+    # CHANGED: Replaced save_to_file with download
+    download: bool = Form(False),
+    # CHANGED: Added annotation_model parameter
+    annotation_model: AnnotationModel = Form("gpt-4o-mini")
 ):
     """
     Chunk a document file (PDF, DOCX, PPTX) according to the specified strategy.
@@ -26,12 +39,22 @@ async def chunk_document(
         strategy: Chunking strategy to use
         chunk_size: Size of chunks for fixed strategy (in characters)
         overlap: Overlap size for fixed strategy (in characters)
+        output_format: Output format (json or markdown)
+        use_collapsible: Use collapsible sections in Markdown output
+        - markdown_template (str, optional): Markdown template style (table, list, compact, nested, default: "table")
+        metadata_fields: Comma-separated list of metadata fields to include
+        annotate: Include content-based annotations in Markdown
+        download: Return Markdown output as a downloadable file
+        annotation_model: OpenAI model for annotations (gpt-4o-mini or gpt-4o)
 
     Returns:
-        JSON response with chunks and metadata
+        JSON or Markdown response based on output_format and save_to_file
     """
     logger.info(f"Received request for document chunking using {strategy} strategy")
     logger.debug(f"Document file name: {document_file.filename}")
+
+    # CHANGED: Parse metadata_fields
+    metadata_fields_list = metadata_fields.split(",") if metadata_fields else None
 
     # Check file type from filename
     file_name = document_file.filename.lower()
@@ -51,6 +74,7 @@ async def chunk_document(
         )
 
     file_path = None  # Initialize file_path
+    markdown_file_path = None
     try:
         # Read file content
         file_content = await document_file.read()
@@ -63,20 +87,58 @@ async def chunk_document(
 
         # Process the document with the requested chunking strategy
         result = process_document_chunking(
-            file_path, file_type, strategy, chunk_size, overlap
+            file_path, file_type, strategy, chunk_size, overlap, output_format, use_collapsible, markdown_template, metadata_fields_list, annotate, annotation_model
         )
 
-        logger.info(f"Document chunking completed with {result['total_chunks']} chunks")
+        # logger.info(f"Document chunking completed with {result['total_chunks']} chunks")
+        logger.info(
+            f"Document chunking completed with "
+            f"{result['total_chunks'] if output_format == 'json' else 'Markdown output'}"
+        )
+        # CHANGED: Handle file export for Markdown
+        if output_format == "markdown" and download:
+            try:
+                # Create a temporary file with a unique name
+                markdown_file_path = os.path.join(tempfile.gettempdir(), f"{document_file.filename.rsplit('.', 1)[0]}_chunks_{os.urandom(4).hex()}.md")
+                # Use aiofiles for asynchronous file writing
+                async with aiofiles.open(markdown_file_path, "w", encoding="utf-8") as f:
+                    await f.write(result)
+                # Ensure file exists before serving
+                if not os.path.exists(markdown_file_path):
+                    raise FileNotFoundError(f"Markdown file not found: {markdown_file_path}")
+                return FileResponse(
+                    markdown_file_path,
+                    media_type="text/markdown",
+                    filename=f"{document_file.filename.rsplit('.', 1)[0]}_chunks.md",
+                    background=BackgroundTask(os.unlink, markdown_file_path)
+                )
+            except Exception as e:
+                logger.error(f"Failed to create Markdown file: {str(e)}")
+                raise HTTPException(status_code=500, detail=f"Failed to create Markdown file: {str(e)}")
+        
+        # CHANGED: Return PlainTextResponse for Markdown
+        if output_format == "markdown":
+            return PlainTextResponse(content=result, media_type="text/markdown")
         return JSONResponse(content=result)
 
+    # except Exception as e:
+    #     logger.error(f"Error processing document: {str(e)}", exc_info=True)
+    #     raise HTTPException(
+    #         status_code=500, detail=f"Error processing document: {str(e)}"
+    #     )
+
+    except ValueError as ve:
+        logger.error(f"Validation error: {str(ve)}")
+        raise HTTPException(status_code=400, detail=str(ve))
     except Exception as e:
         logger.error(f"Error processing document: {str(e)}", exc_info=True)
-        raise HTTPException(
-            status_code=500, detail=f"Error processing document: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Error processing document: {str(e)}")
 
     finally:
         # Clean up the temporary file
         if file_path and os.path.exists(file_path):
             logger.debug(f"Cleaning up temporary file: {file_path}")
             os.unlink(file_path)
+        # if markdown_file_path and os.path.exists(markdown_file_path):
+        #     logger.debug(f"Cleaning up temporary Markdown file: {markdown_file_path}")
+        #     os.unlink(markdown_file_path)

--- a/Unsiloed/services/chunking.py
+++ b/Unsiloed/services/chunking.py
@@ -4,24 +4,197 @@ from Unsiloed.utils.chunking import (
     paragraph_chunking,
     heading_chunking,
     semantic_chunking,
+    ChunkingStrategy
 )
 from Unsiloed.utils.openai import (
     extract_text_from_pdf,
     extract_text_from_docx,
     extract_text_from_pptx,
+    get_openai_client
 )
 
+# CHANGED: Import template functions
+from Unsiloed.config.templates import table_template, list_template, compact_template, nested_template
 import logging
+from typing import Literal, List, Dict, Any
+import json
 
 logger = logging.getLogger(__name__)
 
+# CHANGED: Added OutputFormat type for JSON or Markdown output
+OutputFormat = Literal["json", "markdown"]
+# CHANGED: Added MarkdownTemplate type
+MarkdownTemplate = Literal["table", "list", "compact", "nested"]
+# CHANGED: Added annotation model type
+AnnotationModel = Literal["gpt-4o-mini", "gpt-4o"]
 
+# CHANGED: Added function for content-based annotations
+# CHANGED: Replaced with OpenAI-powered annotation
+def annotate_chunk(chunk: Dict[str, Any], model: AnnotationModel = "gpt-4o-mini") -> str:
+    """
+    Generate an annotation tag for a chunk based on its content.
+
+    Args:
+        chunk: Chunk dictionary with text and metadata
+        model: OpenAI model to use for annotation
+    Returns:
+        # Annotation tag (e.g., Summary, Code, Quote)
+        Annotation tag (e.g., Introduction, Technical Detail)
+    """
+    # text = chunk["text"].lower()
+    # if "```" in text:
+    #     return "Code"
+    # elif text.startswith(">") or "quote" in text:
+    #     return "Quote"
+    # elif len(text.split()) < 50:
+    #     return "Summary"
+    # return "Content"
+
+        # Simple cache to avoid redundant API calls
+    cache: Dict[str, str] = {}
+    text = chunk["text"][:1000]  # Limit to 1000 chars for efficiency
+    text_hash = hash(text)
+    if text_hash in cache:
+        return cache[text_hash]
+
+    try:
+        openai_client = get_openai_client()
+        response = openai_client.chat.completions.create(
+            model=model,
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are an expert at analyzing text. Provide a single, concise label (1-2 words) that describes the primary purpose or type of the following text chunk (e.g., Introduction, Technical Detail, Conclusion, Code, Quote).",
+                },
+                {
+                    "role": "user",
+                    "content": text,
+                },
+            ],
+            max_tokens=10,
+            temperature=0.3,
+        )
+        annotation = response.choices[0].message.content.strip()
+        cache[text_hash] = annotation
+        return annotation
+    except Exception as e:
+        logger.warning(f"OpenAI annotation failed: {str(e)}. Using fallback.")
+        # Fallback to basic heuristic
+        if "```" in text:
+            return "Code"
+        elif text.startswith(">"):
+            return "Quote"
+        elif len(text.split()) < 50:
+            return "Summary"
+        return "Content"
+
+# CHANGED: Updated to support templates, metadata filtering, and annotations
+def format_chunks_as_markdown(chunks: List[dict],
+    use_collapsible: bool = False,
+    template: MarkdownTemplate = "table",
+    metadata_fields: List[str] = None,
+    annotate: bool = False,
+    # CHANGED: Added annotation_model parameter
+    annotation_model: AnnotationModel = "gpt-4o-mini"
+) -> str:
+    """
+    Convert chunks to Markdown format with headings, tables, and optional collapsible sections.
+
+    Args:
+        chunks: List of chunk dictionaries with text and metadata
+        use_collapsible: Whether to wrap chunks in collapsible sections
+        template: Markdown template style (table or list)
+        metadata_fields: List of metadata fields to include (None for all)
+        annotate: Whether to include content-based annotations
+        annotation_model: OpenAI model for annotations
+    Returns:
+        Markdown-formatted string
+    """
+
+    if metadata_fields is None:
+        metadata_fields = ["title", "heading", "position", "start_char", "end_char", "strategy", "page"]
+
+    # Select template
+    # Select template
+    template_funcs = {
+        "table": table_template,
+        "list": list_template,
+        "compact": compact_template,
+        "nested": nested_template
+    }
+    template_func = template_funcs.get(template, table_template)
+    markdown = template_func(chunks, use_collapsible, metadata_fields)
+
+    # Add annotations if requested
+    if annotate:
+        annotated_markdown = "# Document Chunks with Annotations\n\n"
+        for i, chunk in enumerate(chunks, 1):
+            tag = annotate_chunk(chunk, annotation_model)
+            metadata = chunk.get("metadata", {})
+            heading = metadata.get("title") or metadata.get("heading") or f"Chunk {i}"
+            annotated_markdown += f"### {heading} [{tag}]\n\n"
+            if use_collapsible:
+                annotated_markdown += f"<details><summary>{heading} [{tag}]</summary>\n\n"
+                annotated_markdown += f"{chunk['text']}\n\n"
+                annotated_markdown += "</details>\n\n"
+            else:
+                annotated_markdown += f"{chunk['text']}\n\n"
+        return annotated_markdown
+
+    return markdown
+    # if not chunks:
+    #     return "# Document Chunks\n\nNo chunks generated."
+    # markdown = "# Document Chunks\n\n"
+    # markdown += "## Chunk Summary\n\n"
+    # markdown += "| Index | Text Preview | Metadata |\n"
+    # markdown += "|-------|--------------|----------|\n"
+    # for i, chunk in enumerate(chunks, 1):
+    #     text = chunk["text"].replace("\n", " ").strip()[:50] + "..."  # Preview
+    #     metadata = chunk.get("metadata", {})
+    #     metadata_str = ", ".join(f"{k}: {v}" for k, v in metadata.items())
+
+        # Use title or heading if available, else generic
+    #     heading = metadata.get("title") or metadata.get("heading") or f"Chunk {i}"
+        
+    #     # Add chunk details
+    #     markdown += f"| {i} | {text} | {metadata_str} |\n"
+
+    # markdown += "\n## Chunk Details\n\n"
+
+    # for i, chunk in enumerate(chunks, 1):
+    #     metadata = chunk.get("metadata", {})
+    #     heading = metadata.get("title") or metadata.get("heading") or f"Chunk {i}"
+    #     markdown += f"### {heading}\n\n"
+
+    #     if use_collapsible:
+    #         markdown += f"<details><summary>{heading}</summary>\n\n"
+    #         markdown += f"{chunk['text']}\n\n"
+    #         # CHANGED: Add blockquote for semantic chunk metadata if available
+    #         if metadata.get("strategy") == "semantic" and metadata.get("position"):
+    #             markdown += f"> Position: {metadata['position']}\n\n"
+    #         markdown += "</details>\n\n"
+    #     else:
+    #         markdown += f"{chunk['text']}\n\n"
+    #         if metadata.get("strategy") == "semantic" and metadata.get("position"):
+    #             markdown += f"> Position: {metadata['position']}\n\n"
+
+    # return markdown
 def process_document_chunking(
     file_path,
     file_type,
-    strategy,
+    strategy: ChunkingStrategy,
     chunk_size=1000,
     overlap=100,
+    # CHANGED: Added output_format and use_collapsible parameters
+    output_format: OutputFormat = "json",
+    use_collapsible: bool = False,
+    # CHANGED: Added template, metadata_fields, and annotate parameters
+    markdown_template: MarkdownTemplate = "table",
+    metadata_fields: List[str] = None,
+    annotate: bool = False,
+    # CHANGED: Added annotation_model parameter
+    annotation_model: AnnotationModel = "gpt-4o-mini",
+    download: bool = False
 ):
     """
     Process a document file (PDF, DOCX, PPTX) with the specified chunking strategy.
@@ -32,13 +205,45 @@ def process_document_chunking(
         strategy: Chunking strategy to use
         chunk_size: Size of chunks for fixed strategy
         overlap: Overlap size for fixed strategy
-
+        output_format: Output format (json or markdown)
+        use_collapsible: Use collapsible sections in Markdown output
+        markdown_template (str, optional): Markdown template style (table, list, compact, nested, default: "table")
+        metadata_fields: List of metadata fields to include in Markdown
+        annotate: Include content-based annotations in Markdown
+        annotation_model: OpenAI model for annotations
+        download: Return Markdown output as a downloadable file
     Returns:
-        Dictionary with chunking results
+        Dictionary with chunking results (JSON) or Markdown string
     """
     logger.info(
         f"Processing {file_type.upper()} document with {strategy} chunking strategy"
     )
+
+    # # CHANGED: Validate parameters
+    # if output_format not in ["json", "markdown"]:
+    #     raise ValueError(f"Invalid output_format: {output_format}. Must be 'json' or 'markdown'.")
+    # if markdown_template not in ["table", "list"]:
+    #     raise ValueError(f"Invalid markdown_template: {markdown_template}. Must be 'table' or 'list'.")
+    # if metadata_fields:
+    #     valid_fields = ["title", "heading", "position", "start_char", "end_char", "strategy", "page"]
+    #     invalid_fields = [f for f in metadata_fields if f not in valid_fields]
+    #     if invalid_fields:
+    #         raise ValueError(f"Invalid metadata_fields: {invalid_fields}. Valid fields: {valid_fields}")
+        
+
+    # CHANGED: Updated template validation
+    if output_format not in ["json", "markdown"]:
+        raise ValueError(f"Invalid output_format: {output_format}. Must be 'json' or 'markdown'.")
+    if markdown_template not in ["table", "list", "compact", "nested"]:
+        raise ValueError(f"Invalid markdown_template: {markdown_template}. Must be 'table', 'list', 'compact', or 'nested'.")
+    if metadata_fields:
+        valid_fields = ["title", "heading", "position", "start_char", "end_char", "strategy", "page"]
+        invalid_fields = [f for f in metadata_fields if f not in valid_fields]
+        if invalid_fields:
+            raise ValueError(f"Invalid metadata_fields: {invalid_fields}. Valid fields: {valid_fields}")
+    # CHANGED: Validate annotation_model
+    if annotate and annotation_model not in ["gpt-4o-mini", "gpt-4o"]:
+        raise ValueError(f"Invalid annotation_model: {annotation_model}. Must be 'gpt-4o-mini' or 'gpt-4o'.")
 
     # Handle page-based chunking for PDFs only
     if strategy == "page" and file_type == "pdf":
@@ -71,7 +276,7 @@ def process_document_chunking(
             chunks = paragraph_chunking(text)
         else:
             raise ValueError(f"Unknown chunking strategy: {strategy}")
-
+        
     # Calculate statistics
     total_chunks = len(chunks)
     avg_chunk_size = (
@@ -88,4 +293,7 @@ def process_document_chunking(
         "chunks": chunks,
     }
 
+    # CHANGED: Pass new parameters to format_chunks_as_markdown
+    if output_format == "markdown":
+        return format_chunks_as_markdown(chunks, use_collapsible, markdown_template, metadata_fields, annotate, annotation_model)
     return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ openai
 numpy
 opencv-python-headless
 requests
+aiofiles


### PR DESCRIPTION
Add Markdown Output Support for Chunks (closes : #26)

/claim #26 
#Overview
- [ ] Feature
This add Markdown output support for the chunks for different file formats.

## Description
This PR provides allows different input functions and allows downloading the output in markdown format.
Different Options allowed are:
1.Different Strategy
2.output_format
3.markdown_template (table, compact, nested, list
4.annotation
5.download output markdown file
6.annotation model: gpt-4o-mini, gpt-4o

https://www.loom.com/share/6406d7acb2684e5a92f58c0bb487ed7a?sid=a4ea9fb0-076c-4aa0-baa2-46080bf9657a
## This is the short demo video and provided image
![image](https://github.com/user-attachments/assets/a1d6fe99-f88c-483f-9a64-e88d48cdec3e)
